### PR TITLE
Implement batch processing of CA initialization.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ use yubihsm::{
     Capability, Domain,
 };
 
+pub const KEYSPEC_EXT: &str = ".keyspec.json";
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("failed conversion from YubiHSM Label")]

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -20,9 +20,8 @@ use yubihsm::{
 };
 use zeroize::Zeroize;
 
-use crate::config::KeySpec;
+use crate::config::{KeySpec, KEYSPEC_EXT};
 
-const KEYSPEC_EXT: &str = ".keyspec.json";
 const WRAP_ID: Id = 1;
 
 const ALG: wrap::Algorithm = wrap::Algorithm::Aes256Ccm;


### PR DESCRIPTION
This commit also fixes a bug in how we were formatting key ids in various contexts (must be hex, no '0x' prefix).