### PR TITLE
nixos-compatible shebang + shellcheck + exec bit set

### DIFF
--- a/script/hash-cd.sh
+++ b/script/hash-cd.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 # This script calculates the hash of the ISO FS on a CD or DVD.
 

--- a/script/oks-lib.sh
+++ b/script/oks-lib.sh
@@ -1,10 +1,11 @@
+#!/usr/bin/env bash
 # functions common to oks scripts
 
 CD_DEV=/dev/cdrom
 
 # check that a given command is on PATH, if not exit 1
 command_on_path() {
-    if ! command -v $1 &> /dev/null; then
+    if ! command -v "$1" &> /dev/null; then
         >&2 echo "ERROR: missing required command: $1"
         exit 1
     fi
@@ -24,8 +25,7 @@ fail_with_msg() {
     shift
 
     # catching error output in a temp file would be nice
-    $@
-    if [ $? -ne 0 ]; then
+    if ! "$@"; then
         >&2 echo "ERROR: $MSG"
         exit 1
     fi
@@ -39,14 +39,14 @@ cd_sha256() {
     ISOINFO_OUT=$TMP_DIR/isoinfo.log
     fail_with_msg \
         "failed to get isoinfo for device: \"$DEVICE\"" \
-        isoinfo -d -i $DEVICE > $ISOINFO_OUT
+        isoinfo -d -i "$DEVICE" > "$ISOINFO_OUT"
     
     BLOCK_SIZE=$(sed -n 's/^Logical block size is: \([0-9]\+\)/\1/p' \
-        $ISOINFO_OUT)
+        "$ISOINFO_OUT")
     BLOCK_COUNT=$(sed -n 's/^Volume size is: \([0-9]\+\)/\1/p' \
-        $ISOINFO_OUT)
+        "$ISOINFO_OUT")
     
-    dd if=$CD_DEV bs=$BLOCK_SIZE count=$BLOCK_COUNT status=none \
+    dd if=$CD_DEV bs="$BLOCK_SIZE" count="$BLOCK_COUNT" status=none \
         | sha256sum \
         | awk '{print $1}'
 }

--- a/script/write-iso.sh
+++ b/script/write-iso.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # This script expects a directory name / path as a single positional
 # parameter. The contents of this directory are turned into an ISO and
@@ -11,7 +13,7 @@ command_on_path mkisofs
 command_on_path cdrecord
 
 DIR="$1"
-if [ ! -e $DIR -o ! -d $DIR ]; then
+if [[ ! -e "$DIR" ]] || [[ ! -d "$DIR" ]]; then
     >&2 echo "ERROR: path provided is not a directory: $DIR"
     exit 1
 fi
@@ -26,7 +28,6 @@ echo "INFO: generating iso from directory \"$DIR\""
 fail_with_msg \
     "failed to create ISO from directory: $DIR" \
     mkisofs -r -iso-level 4 -o "$ISO" "$DIR"
-[ $? -ne 0 ] && exit 1
 
 if [ ! -f "$ISO" ]; then
     >&2 echo "ERROR: failed to create iso, not a file: \"$ISO\""
@@ -39,8 +40,8 @@ echo "INFO: ISO has hash sha256-$ISO_HASH"
 # cdrecord is noisy on both stdio and stderr. We can't redirect stderr while
 # using 'fail_with_msg' so we do it manually.
 echo "INFO: writing ISO to device: \"$CD_DEV\""
-cdrecord -silent -data $ISO dev=$CD_DEV > /dev/null 2>&1
-if [ $? -ne 0 ]; then
+
+if ! cdrecord -silent -data "$ISO" dev="$CD_DEV" > /dev/null 2>&1; then
     >&2 echo "ERROR: failed writing ISO to \"$CD_DEV\""
     exit 1
 fi


### PR DESCRIPTION
i haven't tested these for actually working btw because im not really sure how they're used so please make sure that i didnt subtly break behavior

mainly making shellcheck happy with us but also i put in a `set -euo pipefail` for the nicer bail-out behavior. also i set them to `#!/usr/bin/env bash`, which is the preferred way to use bash on NixOS. set the exec bit on them too for good measure so we dont need to do that in the packaging. going to use this commit in the packaging i do on offline-keystore-os for now but we can change that.