### PR TITLE
Update format_csr to use rustc from NixOS 22.11.

### DIFF
--- a/util/format_csr.rs
+++ b/util/format_csr.rs
@@ -4,7 +4,7 @@
 
 use clap::Parser;
 use oks::config::CsrSpec;
-use std::io;
+use std::io::{self, Read};
 use yubihsm::object::Label;
 
 #[derive(Parser, Debug)]
@@ -17,8 +17,10 @@ struct Config {
 
 fn main() -> anyhow::Result<()> {
     let cfg = Config::parse();
+    let mut buf = Vec::new();
 
-    let csr = io::read_to_string(io::stdin())?;
+    io::stdin().read_to_end(&mut buf)?;
+    let csr = String::from_utf8(buf)?;
 
     let csr_spec = CsrSpec {
         label: cfg.label,


### PR DESCRIPTION
NixOS packages rustc 1.64.0 but `std::io::read_to_string` was added in 1.65. Working around this was less work / risk than updating the OS.