### PR TITLE
Increase timeout from 2 minutes to 5.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ enum HsmCommand {
 }
 
 // 2 minute to support RSA4K key generation
-const TIMEOUT_MS: u64 = 120000;
+const TIMEOUT_MS: u64 = 300000;
 
 // Create output directories for the commands that need them
 fn create_required_dirs(args: &Args) -> Result<()> {


### PR DESCRIPTION
I just had the HSM timeout while generating an RSA4k key even with a 4 minute timeout. I'm tempted to make this timeout infinite but we need some way to know when we need intervention in order for the ceremony to proceed. 5 minutes seems conservative enough while still allowing for a meaningful timeout.

This resolves #85 