### PR TITLE
Make `start-session` script more robust.

### DIFF
--- a/script/start-session
+++ b/script/start-session
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-mkdir output
+set -eou pipefail
+
+mkdir -p output
 script --t=output/script-timing.log -a output/script.log


### PR DESCRIPTION
The `mkdir` should have been passed `-p` to begin with. Seting `eou pipefail` isn't explicitly necessary for such a simple script but since our intent is to do this for all scripts we do so here as well.

this resolves #78