### PR TITLE
Fix key share printing

### DIFF
--- a/src/bin/printer-test.rs
+++ b/src/bin/printer-test.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::{fs::OpenOptions, path::PathBuf};
 
 use anyhow::Result;

--- a/src/bin/printer-test.rs
+++ b/src/bin/printer-test.rs
@@ -1,0 +1,53 @@
+use std::{fs::OpenOptions, path::PathBuf};
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use hex::ToHex;
+
+#[derive(Parser)]
+struct Args {
+    #[clap(long, env, default_value = "/dev/usb/lp0")]
+    print_dev: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    RecoveryKeyShare {
+        share_idx: usize,
+        share_count: usize,
+        data_len: usize,
+    },
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    match args.command {
+        Command::RecoveryKeyShare {
+            share_idx,
+            share_count,
+            data_len,
+        } => {
+            let mut print_file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(args.print_dev)?;
+
+            let share_data: Vec<u8> =
+                (0..data_len).map(|x| (x % 256) as u8).collect();
+
+            println!("Data: {}", share_data.encode_hex::<String>());
+
+            oks::hsm::print_share(
+                &mut print_file,
+                share_idx,
+                share_count,
+                &share_data,
+            )
+        }
+    }
+}

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -484,7 +484,7 @@ fn are_you_sure() -> Result<bool> {
 }
 
 #[rustfmt::skip]
-fn print_share(
+pub fn print_share(
     print_file: &mut File,
     share_idx: usize,
     share_count: usize,

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -483,6 +483,7 @@ fn are_you_sure() -> Result<bool> {
     Ok(buffer == "y")
 }
 
+// Format a key share for printing with Epson ESC/P
 #[rustfmt::skip]
 pub fn print_share(
     print_file: &mut File,
@@ -498,20 +499,20 @@ pub fn print_share(
         ESC, '@' as u32 as u8, // Initialize Printer
         ESC, 'x' as u32 as u8, 1, // Select NLQ mode
         ESC, 'k' as u32 as u8, 1, // Select San Serif font
-        ESC, '$' as u32 as u8, 127, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
         ESC, 'E' as u32 as u8, // Select Bold
     ])?;
     print_file.write_all("Oxide Offline Keystore".as_bytes())?;
     print_file.write_all(&[
         LF,
         ESC, 'F' as u32 as u8, // Deselect Bold
-        ESC, '$' as u32 as u8, 127, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
     ])?;
     print_file.write_all("Recovery Key Share ".as_bytes())?;
     print_file.write_all(&[
         ESC, '-' as u32 as u8, 1, // Select underscore
     ])?;
-    print_file.write_all(share_idx.to_string().as_bytes())?;
+    print_file.write_all((share_idx + 1).to_string().as_bytes())?;
     print_file.write_all(&[
         ESC, '-' as u32 as u8, 0, // Deselect underscore
     ])?;
@@ -524,7 +525,6 @@ pub fn print_share(
         ESC, '-' as u32 as u8, 0, // Deselect underscore
         LF,
         LF,
-        LF,
         ESC, 'D' as u32 as u8, 8, 20, 32, 44, 0, // Set horizontal tab stops
     ])?;
 
@@ -534,11 +534,11 @@ pub fn print_share(
         .chunks(8)
         .enumerate()
     {
-        print_file.write_all(&['\t' as u32 as u8])?;
-        print_file.write_all(chunk.encode_hex::<String>().as_bytes())?;
-        if i % 3 == 3 {
+        if i % 4 == 0 {
             print_file.write_all(&[LF])?;
         }
+        print_file.write_all(&['\t' as u32 as u8])?;
+        print_file.write_all(chunk)?;
     }
 
     print_file.write_all(&[FF])?;

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -494,6 +494,12 @@ pub fn print_share(
     const ESC: u8 = 0x1b;
     const LF: u8 = 0x0a;
     const FF: u8 = 0x0c;
+    const CR: u8 = 0x0d;
+
+    // ESC/P specification recommends sending CR before LF and FF.  The latter commands
+    // print the contents of the data buffer before their movement.  This can cause
+    // double printing (bolding) in certain situations.  Sending CR clears the data buffer
+    // without printing so sending it first avoids any double printing.
 
     print_file.write_all(&[
         ESC, '@' as u32 as u8, // Initialize Printer
@@ -504,7 +510,7 @@ pub fn print_share(
     ])?;
     print_file.write_all("Oxide Offline Keystore".as_bytes())?;
     print_file.write_all(&[
-        LF,
+        CR, LF,
         ESC, 'F' as u32 as u8, // Deselect Bold
         ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
     ])?;
@@ -523,8 +529,8 @@ pub fn print_share(
     print_file.write_all(share_count.to_string().as_bytes())?;
     print_file.write_all(&[
         ESC, '-' as u32 as u8, 0, // Deselect underscore
-        LF,
-        LF,
+        CR, LF,
+        CR, LF,
         ESC, 'D' as u32 as u8, 8, 20, 32, 44, 0, // Set horizontal tab stops
     ])?;
 
@@ -535,12 +541,12 @@ pub fn print_share(
         .enumerate()
     {
         if i % 4 == 0 {
-            print_file.write_all(&[LF])?;
+            print_file.write_all(&[CR, LF])?;
         }
         print_file.write_all(&['\t' as u32 as u8])?;
         print_file.write_all(chunk)?;
     }
 
-    print_file.write_all(&[FF])?;
+    print_file.write_all(&[CR, FF])?;
     Ok(())
 }


### PR DESCRIPTION
Built offline-keystore-os w/ this branch.  Verified key shares are printed legibly and `oks hsm restore-all` accepted the key shares and restored the backups.

Fixes #77 