### PR TITLE
Configure certificate serial numbers to conform to LPC55 requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +456,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -577,6 +586,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "oks"
 version = "0.1.0"
 dependencies = [
@@ -586,6 +625,7 @@ dependencies = [
  "fs_extra",
  "hex",
  "log",
+ "num-bigint",
  "p256 0.12.0",
  "pem-rfc7468",
  "rand_chacha 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive", "env"] }
 env_logger = "0.10.0"
 fs_extra = "1.3.0"
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 log = "0.4.17"
+num-bigint = "0.4.3"
 p256 = "0.12"
 pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
 rand_chacha = "0.3.1"

--- a/data/gimlet-rot-code-signing-dev-a.keyspec.json
+++ b/data/gimlet-rot-code-signing-dev-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"gimlet-rot-code-signing-dev-a",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/gimlet-rot-code-signing-dev-b.keyspec.json
+++ b/data/gimlet-rot-code-signing-dev-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"gimlet-rot-code-signing-dev-b",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/gimlet-rot-code-signing-rel-a.keyspec.json
+++ b/data/gimlet-rot-code-signing-rel-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"gimlet-rot-code-signing-rel-a",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/gimlet-rot-code-signing-rel-b.keyspec.json
+++ b/data/gimlet-rot-code-signing-rel-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"gimlet-rot-code-signing-rel-b",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/psc-rot-code-signing-dev-a.keyspec.json
+++ b/data/psc-rot-code-signing-dev-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"psc-rot-code-signing-dev-a",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/psc-rot-code-signing-dev-b.keyspec.json
+++ b/data/psc-rot-code-signing-dev-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"psc-rot-code-signing-dev-b",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/psc-rot-code-signing-rel-a.keyspec.json
+++ b/data/psc-rot-code-signing-rel-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"psc-rot-code-signing-rel-a",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/psc-rot-code-signing-rel-b.keyspec.json
+++ b/data/psc-rot-code-signing-rel-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"psc-rot-code-signing-rel-b",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/sidecar-rot-code-signing-dev-a.keyspec.json
+++ b/data/sidecar-rot-code-signing-dev-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"sidecar-rot-code-signing-dev-a",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/sidecar-rot-code-signing-dev-b.keyspec.json
+++ b/data/sidecar-rot-code-signing-dev-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"sidecar-rot-code-signing-dev-b",
-    "purpose":"DevelopmentCodeSigningCA"
+    "purpose":"DevelopmentCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/sidecar-rot-code-signing-rel-a.keyspec.json
+++ b/data/sidecar-rot-code-signing-rel-a.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"sidecar-rot-code-signing-rel-a",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/data/sidecar-rot-code-signing-rel-b.keyspec.json
+++ b/data/sidecar-rot-code-signing-rel-b.keyspec.json
@@ -6,5 +6,6 @@
     "domain":"DOM1",
     "hash":"Sha384",
     "label":"sidecar-rot-code-signing-rel-b",
-    "purpose":"ReleaseCodeSigningCA"
+    "purpose":"ReleaseCodeSigningCA",
+    "initial_serial_number": "3cc3000000000000000000000000000000000000"
 }

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -81,7 +81,8 @@ default_md                  = {hash:?}
 preserve                    = no
 policy                      = policy_match
 email_in_dn                 = no
-rand_serial                 = no
+# Setting rand_serial to _any_ value, including "no", enables that option
+#rand_serial                = yes
 unique_subject              = yes
 
 [ policy_match ]

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -546,12 +546,11 @@ fn bootstrap_ca(key_spec: &KeySpec, pkcs11_path: &Path) -> Result<()> {
 
     // write initial serial number to 'serial' (echo 1000 > serial)
     let serial = "serial";
-    let sn = 1000u32;
+    let init_serial_hex = format!("{:020x}", key_spec.initial_serial_number);
     debug!(
-        "setting initial serial number to \"{}\" in file \"{}\"",
-        sn, serial
+        "setting initial serial number to \"{init_serial_hex}\" in file \"{serial}\""
     );
-    fs::write(serial, sn.to_string())?;
+    fs::write(serial, init_serial_hex)?;
 
     // create & write out an openssl.cnf
     fs::write(

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use log::{error, warn};
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -133,6 +134,8 @@ struct OksKeySpec {
     pub hash: Hash,
     pub label: OksLabel,
     pub purpose: Purpose,
+    #[serde(with = "hex")]
+    pub initial_serial_number: [u8; 20],
 }
 
 #[derive(Debug)]
@@ -145,6 +148,7 @@ pub struct KeySpec {
     pub hash: Hash,
     pub label: Label,
     pub purpose: Purpose,
+    pub initial_serial_number: BigUint,
 }
 
 impl FromStr for KeySpec {
@@ -170,6 +174,9 @@ impl TryFrom<OksKeySpec> for KeySpec {
             hash: spec.hash,
             label: spec.label.try_into()?,
             purpose: spec.purpose,
+            initial_serial_number: BigUint::from_bytes_be(
+                &spec.initial_serial_number,
+            ),
         })
     }
 }
@@ -265,7 +272,8 @@ mod tests {
         "domain":"DOM1",
         "hash":"Sha256",
         "label":"rot-stage0-signing-root-eng-a",
-        "purpose":"ReleaseCodeSigning"
+        "purpose":"ReleaseCodeSigning",
+        "initial_serial_number":"3cc3000000000000000000000000000000000000"
     }"#;
 
     #[test]
@@ -309,7 +317,8 @@ mod tests {
         "domain":"DOM1",
         "hash":"Sha384",
         "label":"rot-identity-signing-ca",
-        "purpose":"DevelopmentCodeSigning"
+        "purpose":"DevelopmentCodeSigning",
+        "initial_serial_number":"0000000000000000000000000000000000000000"
     }"#;
 
     #[test]
@@ -336,7 +345,8 @@ mod tests {
         "domain":"DOM1",
         "hash":"Sha384",
         "label":"rot-identity-signing-ca",
-        "purpose":"Identity"
+        "purpose":"Identity",
+        "initial_serial_number":"0000000000000000000000000000000000000000"
     }"#;
 
     #[test]


### PR DESCRIPTION
NXP LP55S69 secure boot requires the last certificate in the chain to have a certificate serial number with the first 4 bytes encoding a magic number and a 16-bit revocation ID.  Extend KeySpecs to allow setting an initial serial number and then use that to cause the RoT certificates to fit the necessary encoding.

Tested by going through a commissioning of a Testing OKS and verifying the resulting certificates have serial numbers conforming to NXP's encoding.