### PR TITLE
oks: Do not require each cert issued to have a unique `subject`.

### DIFF
--- a/src/ca.rs
+++ b/src/ca.rs
@@ -83,7 +83,7 @@ policy                      = policy_match
 email_in_dn                 = no
 # Setting rand_serial to _any_ value, including "no", enables that option
 #rand_serial                = yes
-unique_subject              = yes
+unique_subject              = no
 
 [ policy_match ]
 countryName                 = supplied


### PR DESCRIPTION
resolves #102 