### PR TITLE
Accept password for auth & creation of the auth credential through env.

### DIFF
--- a/script/ceremony
+++ b/script/ceremony
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+. oks-lib.sh
+
+while true; do
+    echo -n "Enter a password: "
+    read -s PASSWD0
+    echo
+    read -s -p "Retype a password: " PASSWD1
+    echo
+    if [ "$PASSWD0" == "$PASSWD1" ]; then
+        break
+    else
+        echo "Passwords entered do not match. Try again."
+    fi
+done
+
+info "Initializing HSM"
+OKS_NEW_PASSWORD="$PASSWD0" PRINT_DEV=print.log oks hsm initialize
+
+info "Generating keys"
+OKS_PASSWORD="$PASSWD0" KEY_SPEC=data/ oks hsm generate
+
+info "Initializing CAs"
+OKS_PASSWORD="$PASSWD0" KEY_SPEC=data/ oks ca initialize
+
+info "Signing CSRs"
+OKS_PASSWORD="$PASSWD0" CSR_SPEC=data/ oks ca sign

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -19,7 +19,9 @@ use std::{
 use tempfile::{NamedTempFile, TempDir};
 use thiserror::Error;
 
-use crate::config::{self, CsrSpec, KeySpec, Purpose, KEYSPEC_EXT};
+use crate::config::{
+    self, CsrSpec, KeySpec, Purpose, ENV_PASSWORD, KEYSPEC_EXT,
+};
 
 /// Name of file in root of a CA directory with key spec used to generate key
 /// in HSM.
@@ -148,7 +150,11 @@ rotCodeSigningDevelopmentPolicy = 1.3.6.1.4.1.57551.1.2
 /// PKCS#11 module knows which key to use
 fn passwd_to_env(env_str: &str) -> Result<()> {
     let mut password = "0002".to_string();
-    password.push_str(&rpassword::prompt_password("Enter YubiHSM Password: ")?);
+    let passwd = match env::var(ENV_PASSWORD).ok() {
+        Some(p) => p,
+        None => rpassword::prompt_password("Enter YubiHSM Password: ")?,
+    };
+    password.push_str(&passwd);
     std::env::set_var(env_str, password);
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,10 @@ use yubihsm::{
     Capability, Domain,
 };
 
+// string for environment variable used to pass in the authentication
+// password for the HSM
+pub const ENV_PASSWORD: &str = "OKS_PASSWORD";
+
 pub const KEYSPEC_EXT: &str = ".keyspec.json";
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This includes an exmaple script that automates the whole ceremony while challenging the user for the password just once. This script will likely become another rust command line tool that does effectively the same thing.

this resolves #83 and #112