### PR TITLE
Zeroize secrets with the Zeroizing wrapper.

### DIFF
--- a/src/ca.rs
+++ b/src/ca.rs
@@ -18,6 +18,7 @@ use std::{
 };
 use tempfile::{NamedTempFile, TempDir};
 use thiserror::Error;
+use zeroize::Zeroizing;
 
 use crate::config::{
     self, CsrSpec, KeySpec, Purpose, ENV_PASSWORD, KEYSPEC_EXT,
@@ -149,11 +150,11 @@ rotCodeSigningDevelopmentPolicy = 1.3.6.1.4.1.57551.1.2
 /// the cert). We also prefix the password with '0002' so the YubiHSM
 /// PKCS#11 module knows which key to use
 fn passwd_to_env(env_str: &str) -> Result<()> {
-    let mut password = "0002".to_string();
-    let passwd = match env::var(ENV_PASSWORD).ok() {
+    let mut password = Zeroizing::new("0002".to_string());
+    let passwd = Zeroizing::new(match env::var(ENV_PASSWORD).ok() {
         Some(p) => p,
         None => rpassword::prompt_password("Enter YubiHSM Password: ")?,
-    };
+    });
     password.push_str(&passwd);
     std::env::set_var(env_str, password);
 

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -25,7 +25,7 @@ use yubihsm::{
     wrap::{self, Message},
     Capability, Client, Connector, Credentials, Domain, UsbConfig,
 };
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::config::{self, KeySpec, KEYSPEC_EXT};
 
@@ -216,12 +216,13 @@ impl Hsm {
     // NOTE: This function consume self because it deletes the auth credential
     // that was used to create the client object. To use the HSM after calling
     // this function you'll need to reauthenticate.
-    pub fn replace_default_auth(self, mut password: String) -> Result<()> {
+    pub fn replace_default_auth(
+        self,
+        password: Zeroizing<String>,
+    ) -> Result<()> {
         info!("Setting up new auth credential.");
-        // not compatible with Zeroizing wrapper
+        // Key implements Zeroize internally on drop
         let auth_key = Key::derive_from_password(password.as_bytes());
-
-        password.zeroize();
 
         debug!("putting new auth key from provided password");
         // create a new auth key


### PR DESCRIPTION
Using the wrapper makes things more clear / obvious. Having to call `zeroize()` manually is error prone.

resolves #127 