### PR TITLE
Batch of printer formatting fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.9",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +716,7 @@ dependencies = [
  "serde_json",
  "static_assertions",
  "tempfile",
+ "textwrap",
  "thiserror",
  "vsss-rs",
  "yubihsm",
@@ -1079,6 +1100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1260,22 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "num-bigint",
  "p256 0.12.0",
  "pem-rfc7468",
+ "rand",
  "rand_chacha 0.3.1",
  "rpassword",
  "serde",
@@ -818,6 +819,17 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand_chacha"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4.17"
 num-bigint = "0.4.3"
 p256 = "0.12"
 pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
+rand = "0.8.5"
 rand_chacha = "0.3.1"
 rpassword = "7.2.0"
 serde = "1.0.153"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = "1.0.153"
 serde_json = "1.0.94"
 static_assertions = "1.1.0"
 tempfile = "3.4.0"
+textwrap = "0.16.0"
 thiserror = "1.0.39"
 vsss-rs = "2.7.1"
 yubihsm = { version = "0.41.0", features = ["usb"] }

--- a/src/bin/printer-test.rs
+++ b/src/bin/printer-test.rs
@@ -23,8 +23,11 @@ struct Args {
 #[derive(Subcommand)]
 enum Command {
     RecoveryKeyShare {
+        #[clap(default_value_t = 1)]
         share_idx: usize,
+        #[clap(default_value_t = 5)]
         share_count: usize,
+        #[clap(default_value_t = 33)]
         data_len: usize,
     },
     HsmPassword {

--- a/src/bin/printer-test.rs
+++ b/src/bin/printer-test.rs
@@ -7,6 +7,9 @@ use std::{fs::OpenOptions, path::PathBuf};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use hex::ToHex;
+use oks::hsm::Alphabet;
+use rand::{thread_rng, Rng};
+use zeroize::Zeroizing;
 
 #[derive(Parser)]
 struct Args {
@@ -23,6 +26,10 @@ enum Command {
         share_idx: usize,
         share_count: usize,
         data_len: usize,
+    },
+    HsmPassword {
+        #[clap(default_value_t = 16)]
+        length: usize,
     },
 }
 
@@ -52,6 +59,12 @@ fn main() -> Result<()> {
                 share_count,
                 &share_data,
             )
+        }
+        Command::HsmPassword { length } => {
+            let password = Alphabet::new()
+                .get_random_string(|| Ok(thread_rng().gen::<u8>()), length)?;
+            let password = Zeroizing::new(password);
+            oks::hsm::print_password(&args.print_dev, &password)
         }
     }
 }

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -681,6 +681,7 @@ pub fn print_password(
 ) -> Result<()> {
     const ESC: u8 = 0x1b;
     const LF: u8 = 0x0a;
+    const FF: u8 = 0x0c;
     const CR: u8 = 0x0d;
 
     println!(
@@ -738,6 +739,6 @@ pub fn print_password(
         print_file.write_all(chunk)?;
     }
 
-    print_file.write_all(&[CR, LF])?;
+    print_file.write_all(&[CR, FF])?;
     Ok(())
 }

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -616,6 +616,11 @@ fn are_you_sure() -> Result<bool> {
     Ok(buffer == "y")
 }
 
+const ESC: u8 = 0x1b;
+const LF: u8 = 0x0a;
+const FF: u8 = 0x0c;
+const CR: u8 = 0x0d;
+
 // Format a key share for printing with Epson ESC/P
 #[rustfmt::skip]
 pub fn print_share(
@@ -624,11 +629,6 @@ pub fn print_share(
     share_count: usize,
     share_data: &[u8],
 ) -> Result<()> {
-    const ESC: u8 = 0x1b;
-    const LF: u8 = 0x0a;
-    const FF: u8 = 0x0c;
-    const CR: u8 = 0x0d;
-
     // ESC/P specification recommends sending CR before LF and FF.  The latter commands
     // print the contents of the data buffer before their movement.  This can cause
     // double printing (bolding) in certain situations.  Sending CR clears the data buffer
@@ -690,11 +690,6 @@ pub fn print_password(
     print_dev: &Path,
     password: &Zeroizing<String>,
 ) -> Result<()> {
-    const ESC: u8 = 0x1b;
-    const LF: u8 = 0x0a;
-    const FF: u8 = 0x0c;
-    const CR: u8 = 0x0d;
-
     println!(
         "\nWARNING: The HSM authentication password has been created and stored in\n\
         the YubiHSM. It will now be printed to {}.\n\

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -624,36 +624,36 @@ pub fn print_share(
     // without printing so sending it first avoids any double printing.
 
     print_file.write_all(&[
-        ESC, '@' as u32 as u8, // Initialize Printer
-        ESC, 'x' as u32 as u8, 1, // Select NLQ mode
-        ESC, 'k' as u32 as u8, 1, // Select San Serif font
-        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
-        ESC, 'E' as u32 as u8, // Select Bold
+        ESC, b'@', // Initialize Printer
+        ESC, b'x', 1, // Select NLQ mode
+        ESC, b'k', 1, // Select San Serif font
+        ESC, b'$', 112, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, b'E', // Select Bold
     ])?;
-    print_file.write_all("Oxide Offline Keystore".as_bytes())?;
+    print_file.write_all(b"Oxide Offline Keystore")?;
     print_file.write_all(&[
         CR, LF,
-        ESC, 'F' as u32 as u8, // Deselect Bold
-        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, b'F', // Deselect Bold
+        ESC, b'$', 112, 0, // Move to absolute horizontal position (0*256)+127
     ])?;
-    print_file.write_all("Recovery Key Share ".as_bytes())?;
+    print_file.write_all(b"Recovery Key Share ")?;
     print_file.write_all(&[
-        ESC, '-' as u32 as u8, 1, // Select underscore
+        ESC, b'-', 1, // Select underscore
     ])?;
     print_file.write_all((share_idx + 1).to_string().as_bytes())?;
     print_file.write_all(&[
-        ESC, '-' as u32 as u8, 0, // Deselect underscore
+        ESC, b'-', 0, // Deselect underscore
     ])?;
     print_file.write_all(" of ".as_bytes())?;
     print_file.write_all(&[
-        ESC, '-' as u32 as u8, 1, // Select underscore
+        ESC, b'-', 1, // Select underscore
     ])?;
     print_file.write_all(share_count.to_string().as_bytes())?;
     print_file.write_all(&[
-        ESC, '-' as u32 as u8, 0, // Deselect underscore
+        ESC, b'-', 0, // Deselect underscore
         CR, LF,
         CR, LF,
-        ESC, 'D' as u32 as u8, 8, 20, 32, 44, 0, // Set horizontal tab stops
+        ESC, b'D', 8, 20, 32, 44, 0, // Set horizontal tab stops
     ])?;
 
     for (i, chunk) in share_data
@@ -665,7 +665,7 @@ pub fn print_share(
         if i % 4 == 0 {
             print_file.write_all(&[CR, LF])?;
         }
-        print_file.write_all(&['\t' as u32 as u8])?;
+        print_file.write_all(&[b'\t'])?;
         print_file.write_all(chunk)?;
     }
 
@@ -707,23 +707,23 @@ pub fn print_password(
     // without printing so sending it first avoids any double printing.
 
     print_file.write_all(&[
-        ESC, '@' as u32 as u8, // Initialize Printer
-        ESC, 'x' as u32 as u8, 1, // Select NLQ mode
-        ESC, 'k' as u32 as u8, 1, // Select San Serif font
-        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
-        ESC, 'E' as u32 as u8, // Select Bold
+        ESC, b'@', // Initialize Printer
+        ESC, b'x', 1, // Select NLQ mode
+        ESC, b'k', 1, // Select San Serif font
+        ESC, b'$', 112, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, b'E', // Select Bold
     ])?;
-    print_file.write_all("Oxide Offline Keystore".as_bytes())?;
+    print_file.write_all(b"Oxide Offline Keystore")?;
     print_file.write_all(&[
         CR, LF,
-        ESC, 'F' as u32 as u8, // Deselect Bold
-        ESC, '$' as u32 as u8, 112, 0, // Move to absolute horizontal position (0*256)+127
+        ESC, b'F', // Deselect Bold
+        ESC, b'$', 112, 0, // Move to absolute horizontal position (0*256)+127
     ])?;
-    print_file.write_all("HSM Password ".as_bytes())?;
+    print_file.write_all(b"HSM Password ")?;
     print_file.write_all(&[
         CR, LF,
         CR, LF,
-        ESC, 'D' as u32 as u8, 8, 20, 32, 44, 0, // Set horizontal tab stops
+        ESC, b'D', 8, 20, 32, 44, 0, // Set horizontal tab stops
         CR, LF,
     ])?;
 
@@ -735,7 +735,7 @@ pub fn print_password(
         if i % 4 == 0 {
             print_file.write_all(&[CR, LF])?;
         }
-        print_file.write_all(&['\t' as u32 as u8])?;
+        print_file.write_all(&[b'\t'])?;
         print_file.write_all(chunk)?;
     }
 

--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -621,6 +621,27 @@ const LF: u8 = 0x0a;
 const FF: u8 = 0x0c;
 const CR: u8 = 0x0d;
 
+fn print_whitespace_notice(
+    print_file: &mut File,
+    data_type: &str,
+) -> Result<()> {
+    print_file.write_all(&[
+        ESC, b'$', 0, 0, // Move to left edge
+    ])?;
+
+    let options = textwrap::Options::new(70)
+        .initial_indent("     NOTE: ")
+        .subsequent_indent("           ");
+    let text = format!("Whitespace is a visual aid only and must be omitted when entering the {data_type}");
+
+    for line in textwrap::wrap(&text, options) {
+        print_file.write_all(&[CR, LF])?;
+        print_file.write_all(line.as_bytes())?;
+    }
+
+    Ok(())
+}
+
 // Format a key share for printing with Epson ESC/P
 #[rustfmt::skip]
 pub fn print_share(
@@ -679,6 +700,10 @@ pub fn print_share(
         print_file.write_all(&[b'\t'])?;
         print_file.write_all(chunk)?;
     }
+
+    print_file.write_all(&[CR, LF])?;
+
+    print_whitespace_notice(print_file, "recovery key share")?;
 
     print_file.write_all(&[CR, FF])?;
     Ok(())
@@ -744,6 +769,10 @@ pub fn print_password(
         print_file.write_all(&[b'\t'])?;
         print_file.write_all(chunk)?;
     }
+
+    print_file.write_all(&[CR, LF])?;
+
+    print_whitespace_notice(&mut print_file, "HSM password")?;
 
     print_file.write_all(&[CR, FF])?;
     Ok(())


### PR DESCRIPTION
- Avoid visually simlar characters when generating HSM passwords
- Eject paper after printing HSM password
- Use byte and byte string literals instead of converting from unicode
- printer-test for hsm password printouts
- include notice about whitespace in printouts