### PR TITLE
Add 'self_signed' to keyspec enabling `oks` to create intermediate CAs.

### DIFF
--- a/data/gimlet-rot-code-signing-dev-a.keyspec.json
+++ b/data/gimlet-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"gimlet-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/gimlet-rot-code-signing-dev-b.keyspec.json
+++ b/data/gimlet-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"gimlet-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/gimlet-rot-code-signing-rel-a.keyspec.json
+++ b/data/gimlet-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"gimlet-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/gimlet-rot-code-signing-rel-b.keyspec.json
+++ b/data/gimlet-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"gimlet-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/platform-identity-root-a.keyspec.json
+++ b/data/platform-identity-root-a.keyspec.json
@@ -1,0 +1,12 @@
+{
+    "common_name": "Platform Identity Root A",
+    "id":13,
+    "algorithm":"Ecp384",
+    "capabilities":"All",
+    "domain":"DOM1",
+    "hash":"Sha384",
+    "label":"platform-identity-root-a",
+    "purpose":"Identity",
+    "initial_serial_number":"0000000000000000000000000000000000000000",
+    "self_signed":true
+}

--- a/data/psc-rot-code-signing-dev-a.keyspec.json
+++ b/data/psc-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"psc-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/psc-rot-code-signing-dev-b.keyspec.json
+++ b/data/psc-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"psc-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/psc-rot-code-signing-rel-a.keyspec.json
+++ b/data/psc-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"psc-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/psc-rot-code-signing-rel-b.keyspec.json
+++ b/data/psc-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"psc-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/sidecar-rot-code-signing-dev-a.keyspec.json
+++ b/data/sidecar-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"sidecar-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/sidecar-rot-code-signing-dev-b.keyspec.json
+++ b/data/sidecar-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"sidecar-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/sidecar-rot-code-signing-rel-a.keyspec.json
+++ b/data/sidecar-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"sidecar-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/data/sidecar-rot-code-signing-rel-b.keyspec.json
+++ b/data/sidecar-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha384",
     "label":"sidecar-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/gimlet-rot-code-signing-dev-a.keyspec.json
+++ b/specs/production/gimlet-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/gimlet-rot-code-signing-dev-b.keyspec.json
+++ b/specs/production/gimlet-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/gimlet-rot-code-signing-rel-a.keyspec.json
+++ b/specs/production/gimlet-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/gimlet-rot-code-signing-rel-b.keyspec.json
+++ b/specs/production/gimlet-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/psc-rot-code-signing-dev-a.keyspec.json
+++ b/specs/production/psc-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/psc-rot-code-signing-dev-b.keyspec.json
+++ b/specs/production/psc-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/psc-rot-code-signing-rel-a.keyspec.json
+++ b/specs/production/psc-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/psc-rot-code-signing-rel-b.keyspec.json
+++ b/specs/production/psc-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/sidecar-rot-code-signing-dev-a.keyspec.json
+++ b/specs/production/sidecar-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/sidecar-rot-code-signing-dev-b.keyspec.json
+++ b/specs/production/sidecar-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/sidecar-rot-code-signing-rel-a.keyspec.json
+++ b/specs/production/sidecar-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/production/sidecar-rot-code-signing-rel-b.keyspec.json
+++ b/specs/production/sidecar-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/gimlet-rot-code-signing-dev-a.keyspec.json
+++ b/specs/staging/gimlet-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/gimlet-rot-code-signing-dev-b.keyspec.json
+++ b/specs/staging/gimlet-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/gimlet-rot-code-signing-rel-a.keyspec.json
+++ b/specs/staging/gimlet-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/gimlet-rot-code-signing-rel-b.keyspec.json
+++ b/specs/staging/gimlet-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"gimlet-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/psc-rot-code-signing-dev-a.keyspec.json
+++ b/specs/staging/psc-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/psc-rot-code-signing-dev-b.keyspec.json
+++ b/specs/staging/psc-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/psc-rot-code-signing-rel-a.keyspec.json
+++ b/specs/staging/psc-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/psc-rot-code-signing-rel-b.keyspec.json
+++ b/specs/staging/psc-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"psc-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/sidecar-rot-code-signing-dev-a.keyspec.json
+++ b/specs/staging/sidecar-rot-code-signing-dev-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-dev-a",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/sidecar-rot-code-signing-dev-b.keyspec.json
+++ b/specs/staging/sidecar-rot-code-signing-dev-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-dev-b",
     "purpose":"RoTDevelopmentRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/sidecar-rot-code-signing-rel-a.keyspec.json
+++ b/specs/staging/sidecar-rot-code-signing-rel-a.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-rel-a",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/specs/staging/sidecar-rot-code-signing-rel-b.keyspec.json
+++ b/specs/staging/sidecar-rot-code-signing-rel-b.keyspec.json
@@ -7,5 +7,6 @@
     "hash":"Sha256",
     "label":"sidecar-rot-rel-b",
     "purpose":"RoTReleaseRoot",
-    "initial_serial_number": "3cc3000000000000000000000000000000000000"
+    "initial_serial_number": "3cc3000000000000000000000000000000000000",
+    "self_signed":true
 }

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -339,45 +339,52 @@ fn initialize_keyspec(
         return Err(CaError::SelfCertGenFail.into());
     }
 
-    // sleep to let sessions cycle
-    thread::sleep(Duration::from_millis(1500));
+    if spec.self_signed {
+        // sleep to let sessions cycle
+        thread::sleep(Duration::from_millis(1500));
 
-    //  generate cert for CA root
-    info!("Generating self-signed cert for CA root");
-    let mut cmd = Command::new("openssl");
-    let output = cmd
-        .arg("ca")
-        .arg("-batch")
-        .arg("-selfsign")
-        .arg("-notext")
-        .arg("-config")
-        .arg("openssl.cnf")
-        .arg("-engine")
-        .arg("pkcs11")
-        .arg("-keyform")
-        .arg("engine")
-        .arg("-keyfile")
-        .arg(format!("0:{:04x}", spec.id))
-        .arg("-extensions")
-        .arg(spec.purpose.to_string())
-        .arg("-passin")
-        .arg("env:OKM_HSM_PKCS11_AUTH")
-        .arg("-in")
-        .arg(&csr.path())
-        .arg("-out")
-        .arg("ca.cert.pem")
-        .output()?;
+        //  generate cert for CA root
+        info!("Generating self-signed cert for CA root");
+        let mut cmd = Command::new("openssl");
+        let output = cmd
+            .arg("ca")
+            .arg("-batch")
+            .arg("-selfsign")
+            .arg("-notext")
+            .arg("-config")
+            .arg("openssl.cnf")
+            .arg("-engine")
+            .arg("pkcs11")
+            .arg("-keyform")
+            .arg("engine")
+            .arg("-keyfile")
+            .arg(format!("0:{:04x}", spec.id))
+            .arg("-extensions")
+            .arg(spec.purpose.to_string())
+            .arg("-passin")
+            .arg("env:OKM_HSM_PKCS11_AUTH")
+            .arg("-in")
+            .arg(&csr.path())
+            .arg("-out")
+            .arg("ca.cert.pem")
+            .output()?;
 
-    debug!("executing command: \"{:#?}\"", cmd);
+        debug!("executing command: \"{:#?}\"", cmd);
 
-    if !output.status.success() {
-        warn!("command failed with status: {}", output.status);
-        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
-        return Err(CaError::SelfCertGenFail.into());
+        if !output.status.success() {
+            warn!("command failed with status: {}", output.status);
+            warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+            return Err(CaError::SelfCertGenFail.into());
+        }
+
+        let cert = out.join(format!("{}.cert.pem", label));
+        fs::copy("ca.cert.pem", cert)?;
+    } else {
+        // when we're not generating a self signed cert we copy the csr
+        // to the output directory so it can be certified through an
+        // external process
+        fs::copy(csr, out.join(format!("{}.csr.pem", label)))?;
     }
-
-    let cert = out.join(format!("{}.cert.pem", label));
-    fs::copy("ca.cert.pem", cert)?;
 
     env::set_current_dir(pwd)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,7 @@ struct OksKeySpec {
     pub purpose: Purpose,
     #[serde(with = "hex")]
     pub initial_serial_number: [u8; 20],
+    pub self_signed: bool,
 }
 
 #[derive(Debug)]
@@ -156,6 +157,7 @@ pub struct KeySpec {
     pub label: Label,
     pub purpose: Purpose,
     pub initial_serial_number: BigUint,
+    pub self_signed: bool,
 }
 
 impl FromStr for KeySpec {
@@ -184,6 +186,7 @@ impl TryFrom<OksKeySpec> for KeySpec {
             initial_serial_number: BigUint::from_bytes_be(
                 &spec.initial_serial_number,
             ),
+            self_signed: spec.self_signed,
         })
     }
 }
@@ -280,7 +283,8 @@ mod tests {
         "hash":"Sha256",
         "label":"rot-stage0-signing-root-eng-a",
         "purpose":"RoTReleaseCodeSigning",
-        "initial_serial_number":"3cc3000000000000000000000000000000000000"
+        "initial_serial_number":"3cc3000000000000000000000000000000000000",
+        "self_signed":true
     }"#;
 
     #[test]
@@ -325,7 +329,8 @@ mod tests {
         "hash":"Sha384",
         "label":"rot-identity-signing-ca",
         "purpose":"RoTDevelopmentCodeSigning",
-        "initial_serial_number":"0000000000000000000000000000000000000000"
+        "initial_serial_number":"0000000000000000000000000000000000000000",
+        "self_signed":true
     }"#;
 
     #[test]
@@ -353,7 +358,8 @@ mod tests {
         "hash":"Sha384",
         "label":"rot-identity-signing-ca",
         "purpose":"Identity",
-        "initial_serial_number":"0000000000000000000000000000000000000000"
+        "initial_serial_number":"0000000000000000000000000000000000000000",
+        "self_signed":true
     }"#;
 
     #[test]


### PR DESCRIPTION
this resolves #139 