### PR TITLE
Oks 0.2.0 pre

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -10,5 +10,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: 1.64.0
+          toolchain: 1.69.0
       - run: cargo fmt --check

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -6,6 +6,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
       with:
-        toolchain: 1.64.0
+        toolchain: 1.69.0
     - name: Check License Header
       uses: apache/skywalking-eyes/header@ed436a5593c63a25f394ea29da61b0ac3731a9fe

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: 1.64.0
+          toolchain: 1.69.0
       - run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libudev-dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64.0
+          toolchain: 1.69.0
       - run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libudev-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "oks"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oks"
-version = "0.1.0"
+version = "0.2.0-pre0"
 description = """
 A utility and library for managing and interacting with the offline keystore.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.81"
-clap = { version = "4.3.19", features = ["derive", "env"] }
+clap = { version = "4.3.24", features = ["derive", "env"] }
 env_logger = "0.10.2"
 fs_extra = "1.3.0"
 hex = { version = "0.4.3", features = ["serde"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.69.0"

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -339,7 +339,7 @@ fn initialize_keyspec(
         .arg("-passin")
         .arg("env:OKM_HSM_PKCS11_AUTH")
         .arg("-out")
-        .arg(&csr.path())
+        .arg(csr.path())
         .output()?;
 
     debug!("executing command: \"{:#?}\"", cmd);
@@ -375,7 +375,7 @@ fn initialize_keyspec(
             .arg("-passin")
             .arg("env:OKM_HSM_PKCS11_AUTH")
             .arg("-in")
-            .arg(&csr.path())
+            .arg(csr.path())
             .arg("-out")
             .arg("ca.cert.pem")
             .output()?;


### PR DESCRIPTION
First step toward 0.2.0 release. This gets us (I think) the latest deps compatible w/ the rustc (v1.69) shipped w/ NixOS 23.05.