### PR TITLE
Use session close function from oxide fork of yubihsm.rs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,8 +2117,7 @@ dependencies = [
 [[package]]
 name = "yubihsm"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467a4c054be41ff657a6823246b0194cd727fadc3c539b265d7bc125ac6d4884"
+source = "git+https://github.com/oxidecomputer/yubihsm.rs?branch=session-close#b61a72247b359f9a19ab70095a76cad14d54714e"
 dependencies = [
  "aes",
  "bitflags 2.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ thiserror = "1.0.58"
 # vsss-rs v3 has a dependency that requires rustc 1.65 but we're pinned
 # to 1.64 till offline-keystore-os supports it
 vsss-rs = "2.7.1"
-yubihsm = { version = "0.42.1", features = ["usb", "untested"] }
+yubihsm = { git = "https://github.com/oxidecomputer/yubihsm.rs", branch = "session-close", features = ["usb", "untested"] }
 zeroize = "1.7.0"

--- a/src/ca.rs
+++ b/src/ca.rs
@@ -474,7 +474,7 @@ pub fn sign(
                 return Err(e);
             }
         } else if filename.ends_with(DCSRSPEC_EXT) {
-            let hsm = Hsm::new(
+            let mut hsm = Hsm::new(
                 0x0002,
                 &passwd_from_env("OKM_HSM_PKCS11_AUTH")?,
                 publish,
@@ -492,6 +492,7 @@ pub fn sign(
                 }
                 return Err(e);
             }
+            hsm.client.close_session()?;
         } else {
             error!("Unknown input spec: {}", path.display());
         }


### PR DESCRIPTION
The `Client` type previously had a `Drop` implementation that closed the session if the Client had an open one. This seems to have caused problems in other downstream projects and was subsequently removed: https://github.com/iqlusioninc/tmkms/issues/37
https://github.com/iqlusioninc/yubihsm.rs/pull/265

The replacement was to provide a `session()` function that returns an Arc / MutexGuard wrapped reference to the optional session. This isn't useful for us here because we don't and AFAIK can't take ownership of the session which we need because the Sesison::close function consumes the session (it can't be reopened). Our solution requires an upstream change to the `Client` type adding a `close_session` function that just closes the session if one is open.

This resolves #190 