### PR TITLE
Cargo.toml: Update version to 0.1.0-pre1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "oks"
-version = "0.2.0-pre0"
+version = "0.2.0-pre1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oks"
-version = "0.2.0-pre0"
+version = "0.2.0-pre1"
 description = """
 A utility and library for managing and interacting with the offline keystore.
 """


### PR DESCRIPTION
The fix to the session exhaustion issue warrants a bump from `pre0` to `pre1`.