### PR TITLE
pretty print the sha256 hash generated by `hash-cd`

### DIFF
--- a/script/hash-cd
+++ b/script/hash-cd
@@ -9,6 +9,11 @@ set -euo pipefail
 TMP_DIR=$(mktemp --directory)
 trap 'rm -rf -- "$TMP_DIR"' EXIT
 
-info "calculating hash of CD in \"$CD_DEV\""
-HASH=$(cd_sha256 "$CD_DEV" "$TMP_DIR")
-info "CD in \"$CD_DEV\" has hash \"sha256-$HASH\""
+info "calculating digest of CD in \"$CD_DEV\""
+HASH=$(
+    cd_sha256 "$CD_DEV" "$TMP_DIR" \
+        | awk '{gsub(/.{2}/,"& ")}1' \
+        | sed 's/ /\n/8;P;D' \
+        | head -c -1
+)
+info "CD in \"$CD_DEV\" has sha256 digest:\n$HASH"

--- a/script/oks-lib.sh
+++ b/script/oks-lib.sh
@@ -8,7 +8,7 @@ error() {
 }
 
 info() {
-    command echo ["$(date --utc +%FT%TZ)" INFO "${0##*/}"] "$@"
+    command echo -e ["$(date --utc +%FT%TZ)" INFO "${0##*/}"] "$@"
 }
 
 # check that a given command is on PATH, if not exit 1


### PR DESCRIPTION
Reading the digest as a single line of hex characters off of the laptop screen is difficult. Breaking the digest up into multiple lines w/ spaces between each byte makes it much easier.