### PR TITLE
Restore `ca-state` to writable part of the disk.

### DIFF
--- a/script/mount-input
+++ b/script/mount-input
@@ -3,9 +3,13 @@
 . oks-lib.sh
 
 DST=input
+CA_STATE=ca-state
 
 info "Creating input directory: $DST"
 mkdir -p "$DST"
 
-info "Mounting /dev/cdrom to: $DST"
+info "Mounting /dev/cdrom at: $DST"
 mount -o ro /dev/cdrom "$DST"
+
+info "Restoing CA state data to: $CA_STATE"
+cp -R "$DST"/"$CA_STATE" ./


### PR DESCRIPTION
This is required for all ceremonies that require the use of the CAs and are carried out after the initial provisioning. This state must be restored *and* writen as output for use in ceremony n+1