### PR TITLE
yhsm: Add command for dealing with the audit log.

### DIFF
--- a/src/hsm.rs
+++ b/src/hsm.rs
@@ -24,7 +24,8 @@ use yubihsm::{
     authentication::{self, Key, DEFAULT_AUTHENTICATION_KEY_ID},
     object::{Id, Label, Type},
     wrap::{self, Message},
-    Capability, Client, Connector, Credentials, Domain, HttpConfig, UsbConfig,
+    AuditOption, Capability, Client, Connector, Credentials, Domain,
+    HttpConfig, UsbConfig,
 };
 use zeroize::Zeroizing;
 
@@ -697,6 +698,14 @@ pub fn reset(client: &Client) -> Result<()> {
         info!("reset aborted");
     }
     Ok(())
+}
+
+pub fn audit_lock(client: &Client) -> Result<()> {
+    if are_you_sure()? {
+        Ok(client.set_force_audit_option(AuditOption::Fix)?)
+    } else {
+        Err(anyhow::anyhow!("command aborted"))
+    }
 }
 
 // consts for our authentication credential


### PR DESCRIPTION
YubiCo docs state that only 1-60 are valid index values. I've set this value to well beyond 60 in testing. These docs don't say what happens when the index (u16) rolls over.

https://docs.yubico.com/hardware/yubihsm-2/hsm-2-user-guide/hsm2-cmd-reference.html#set-log-index-command