### PR TITLE
Refactor `ca` module into a type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "vsss-rs",
+ "x509-cert",
  "yubihsm",
  "zeroize",
 ]
@@ -1958,7 +1959,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,6 @@ thiserror = "1.0.64"
 # vsss-rs v3 has a dependency that requires rustc 1.65 but we're pinned
 # to 1.64 till offline-keystore-os supports it
 vsss-rs = "2.7.1"
+x509-cert = "0.2.5"
 yubihsm = { git = "https://github.com/oxidecomputer/yubihsm.rs", branch = "session-close", features = ["usb", "untested"] }
 zeroize = "1.8.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub const ENV_PASSWORD: &str = "OKS_PASSWORD";
 pub const ENV_NEW_PASSWORD: &str = "OKS_NEW_PASSWORD";
 
 pub const KEYSPEC_EXT: &str = ".keyspec.json";
+pub const CSRSPEC_EXT: &str = ".csrspec.json";
+pub const DCSRSPEC_EXT: &str = ".dcsrspec.json";
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
@@ -42,6 +44,12 @@ pub enum ConfigError {
 
     #[error("failed to parse csr spec from JSON")]
     BadCsrSpec { e: serde_json::Error },
+
+    #[error("Unsupported Algorithm")]
+    UnsupportedAlgorithm,
+
+    #[error("Unsupported Domain")]
+    UnsupportedDomain,
 }
 
 // These structs duplicate data from the yubihsm crate
@@ -61,6 +69,18 @@ impl From<OksAlgorithm> for asymmetric::Algorithm {
     }
 }
 
+impl TryFrom<asymmetric::Algorithm> for OksAlgorithm {
+    type Error = ConfigError;
+
+    fn try_from(val: asymmetric::Algorithm) -> Result<Self, Self::Error> {
+        match val {
+            asymmetric::Algorithm::Rsa4096 => Ok(OksAlgorithm::Rsa4096),
+            asymmetric::Algorithm::EcP384 => Ok(OksAlgorithm::Ecp384),
+            _ => Err(ConfigError::UnsupportedAlgorithm),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 enum OksDomain {
     DOM1,
@@ -70,6 +90,17 @@ impl From<OksDomain> for Domain {
     fn from(val: OksDomain) -> Self {
         match val {
             OksDomain::DOM1 => Domain::DOM1,
+        }
+    }
+}
+
+impl TryFrom<Domain> for OksDomain {
+    type Error = ConfigError;
+
+    fn try_from(val: Domain) -> Result<Self, Self::Error> {
+        match val {
+            Domain::DOM1 => Ok(OksDomain::DOM1),
+            _ => Err(ConfigError::UnsupportedDomain),
         }
     }
 }
@@ -88,6 +119,14 @@ impl TryInto<Label> for OksLabel {
     }
 }
 
+impl TryFrom<Label> for OksLabel {
+    type Error = anyhow::Error;
+
+    fn try_from(val: Label) -> Result<Self, Self::Error> {
+        Ok(Self(String::from(val.try_as_str()?)))
+    }
+}
+
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 enum OksCapability {
     All,
@@ -101,7 +140,19 @@ impl From<OksCapability> for Capability {
     }
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl TryFrom<Capability> for OksCapability {
+    type Error = ConfigError;
+
+    fn try_from(val: Capability) -> Result<Self, Self::Error> {
+        if val == Capability::all() {
+            Ok(OksCapability::All)
+        } else {
+            Err(ConfigError::BadCapability)
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Hash {
     Sha256,
     Sha384,
@@ -109,7 +160,7 @@ pub enum Hash {
 
 /// Values in this enum are mapped to OpenSSL config sections for v3 extensions.
 /// All certs issued by the OKS are assumed to be intermediate CAs.
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Purpose {
     RoTDevelopmentRoot,
     RoTReleaseRoot,
@@ -148,6 +199,37 @@ struct OksKeySpec {
     pub self_signed: bool,
 }
 
+impl TryFrom<&KeySpec> for OksKeySpec {
+    type Error = anyhow::Error;
+
+    fn try_from(spec: &KeySpec) -> Result<Self, Self::Error> {
+        Ok(OksKeySpec {
+            common_name: spec.common_name.clone(),
+            id: spec.id,
+            algorithm: spec.algorithm.try_into()?,
+            capabilities: spec.capabilities.try_into()?,
+            domain: spec.domain.try_into()?,
+            hash: spec.hash,
+            label: spec.label.clone().try_into()?,
+            purpose: spec.purpose,
+            initial_serial_number: match spec
+                .initial_serial_number
+                .to_bytes_be()
+                .try_into()
+            {
+                Ok(sn) => sn,
+                Err(v) => {
+                    return Err(anyhow::anyhow!(
+                        "Expected array of 20 bytes, got {}",
+                        v.len()
+                    ));
+                }
+            },
+            self_signed: spec.self_signed,
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct KeySpec {
     pub common_name: String,
@@ -160,6 +242,13 @@ pub struct KeySpec {
     pub purpose: Purpose,
     pub initial_serial_number: BigUint,
     pub self_signed: bool,
+}
+
+impl KeySpec {
+    pub fn to_json(&self) -> Result<String> {
+        let spec: OksKeySpec = self.try_into()?;
+        Ok(serde_json::to_string(&spec)?)
+    }
 }
 
 impl FromStr for KeySpec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,24 +2,39 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use env_logger::Builder;
 use log::{debug, error, info, LevelFilter};
 use std::{
+    collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 use yubihsm::object::{Id, Type};
 use zeroize::Zeroizing;
 
-use oks::config::{Transport, ENV_NEW_PASSWORD, ENV_PASSWORD};
-use oks::hsm::{self, Hsm};
+use oks::{
+    ca::{Ca, CertOrCsr},
+    config::{
+        self, CsrSpec, DcsrSpec, KeySpec, Transport, CSRSPEC_EXT, DCSRSPEC_EXT,
+        ENV_NEW_PASSWORD, ENV_PASSWORD, KEYSPEC_EXT,
+    },
+    hsm::{self, Hsm},
+};
 
 const PASSWD_PROMPT: &str = "Enter new password: ";
 const PASSWD_PROMPT2: &str = "Enter password again to confirm: ";
 
 const GEN_PASSWD_LENGTH: usize = 16;
+
+// when we write out signed certs to the file system this suffix is appended
+const CERT_SUFFIX: &str = "cert.pem";
+
+// when we write out signed debug credentials to the file system this suffix
+// is appended
+const DCSR_SUFFIX: &str = "dc.bin";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -161,7 +176,7 @@ fn make_dir(path: &Path) -> Result<()> {
         );
         Ok(fs::create_dir_all(path)?)
     } else if !path.is_dir() {
-        Err(anyhow::anyhow!(
+        Err(anyhow!(
             "directory provided is not a directory: \"{}\"",
             path.display()
         ))
@@ -304,16 +319,257 @@ fn do_ceremony(
         )?;
         hsm.generate(key_spec)?;
     }
+
     // set env var for oks::ca module to pickup for PKCS11 auth
     env::set_var(ENV_PASSWORD, &passwd_new);
-    oks::ca::initialize(
-        key_spec,
-        pkcs11_path,
-        &args.state,
-        &args.output,
-        args.transport,
-    )?;
-    oks::ca::sign(csr_spec, &args.state, &args.output, args.transport)
+    // for each key_spec in `key_spec` initialize Ca
+    let cas =
+        initialize_all_ca(key_spec, pkcs11_path, &args.state, &args.output)?;
+    sign_all(&cas, csr_spec, &args.state, &args.output, args.transport)
+}
+
+pub fn initialize_all_ca<P: AsRef<Path>>(
+    key_spec: P,
+    pkcs11_path: P,
+    ca_state: P,
+    out: P,
+) -> Result<HashMap<String, Ca>> {
+    let key_spec = fs::canonicalize(key_spec)?;
+    debug!("canonical KeySpec path: {}", key_spec.display());
+
+    let paths = if key_spec.is_file() {
+        vec![key_spec.clone()]
+    } else {
+        config::files_with_ext(&key_spec, KEYSPEC_EXT)?
+    };
+
+    if paths.is_empty() {
+        return Err(anyhow!(
+            "no files with extension \"{}\" found in dir: {}",
+            KEYSPEC_EXT,
+            &key_spec.display()
+        ));
+    }
+
+    // all state directories for the CAs are created under this directory
+    fs::create_dir_all(ca_state.as_ref()).with_context(|| {
+        format!(
+            "Failed to create directory to hold CA state: {}",
+            ca_state.as_ref().display()
+        )
+    })?;
+
+    let mut map = HashMap::new();
+    for key_spec in paths {
+        let spec = fs::canonicalize(&key_spec)?;
+        debug!("canonical KeySpec path: {}", spec.display());
+
+        if !spec.is_file() {
+            return Err(anyhow!("path to KeySpec isn't a file"));
+        }
+
+        let spec_json = fs::read_to_string(spec)?;
+        let spec = KeySpec::from_str(&spec_json)?;
+
+        let label = spec.label.to_string();
+        let ca_dir = fs::canonicalize(ca_state.as_ref())?.join(&label);
+
+        // Initialize the a CA with the key defined by the KeySpec
+        let cert_or_csr =
+            Ca::initialize(&spec, ca_dir.as_path(), pkcs11_path.as_ref())
+                .with_context(|| {
+                    format!(
+                        "Failed to initialize Ca from keyspec: {}",
+                        key_spec.display()
+                    )
+                })?;
+
+        let (path, pem) = match cert_or_csr {
+            CertOrCsr::Cert(p) => {
+                (out.as_ref().join(format!("{}.cert.pem", spec.label)), p)
+            }
+            CertOrCsr::Csr(p) => {
+                (out.as_ref().join(format!("{}.csr.pem", spec.label)), p)
+            }
+        };
+        fs::write(&path, pem).with_context(|| {
+            format!("Failed to write PEM to path: {}", path.display())
+        })?;
+
+        //
+        let ca = Ca::load(ca_dir.as_path())?;
+        if map.insert(ca.name(), ca).is_some() {
+            return Err(anyhow!("duplicate key label"));
+        }
+    }
+
+    Ok(map)
+}
+
+pub fn load_all_ca<P: AsRef<Path>>(ca_state: P) -> Result<HashMap<String, Ca>> {
+    // find all directories under `ca_state`
+    // for each directory in `ca_state`, Ca::load(directory)
+    // insert into hash map
+    let dirs: Vec<PathBuf> = fs::read_dir(ca_state.as_ref())?
+        .filter(|x| x.is_ok()) // filter out error variant to make unwrap safe
+        .map(|r| r.unwrap().path()) // get paths
+        .filter(|x| x.is_dir()) // filter out every path that isn't a directory
+        .collect();
+    let mut cas: HashMap<String, Ca> = HashMap::new();
+    for dir in dirs {
+        let ca = Ca::load(dir)?;
+        if cas.insert(ca.name(), ca).is_some() {
+            return Err(anyhow!("found CA with duplicate key label"));
+        }
+    }
+
+    Ok(cas)
+}
+
+// Get the CsrSpec from the provided file and use the HashMap of `Ca`s to find
+// the `Ca` that should sign it. Returns a PEM encoded x509 certificate as a
+// Vec<u8>.
+fn sign_csrspec<P: AsRef<Path>>(
+    spec: P,
+    cas: &HashMap<String, Ca>,
+) -> Result<Vec<u8>> {
+    let json = fs::read_to_string(&spec).with_context(|| {
+        format!(
+            "Failed to read CsrSpec json from {}",
+            spec.as_ref().display()
+        )
+    })?;
+    let csr_spec = CsrSpec::from_str(&json)?;
+
+    let ca_name = csr_spec.label.to_string();
+    let signer = cas
+        .get(&ca_name)
+        .ok_or(anyhow!("no CA \"{}\" for CsrSpec", ca_name))?;
+
+    info!("Signing CSR from CsrSpec: {}", spec.as_ref().display());
+    signer.sign_csrspec(&csr_spec)
+}
+
+// Get the DcsrSpec from the provided file, generate a debug credential from
+// it, then sign it with the appropriate `Ca`.
+fn sign_dcsrspec<P: AsRef<Path>>(
+    spec: P,
+    cas: &HashMap<String, Ca>,
+    hsm: &mut Hsm,
+) -> Result<Vec<u8>> {
+    let json = std::fs::read_to_string(&spec).with_context(|| {
+        format!(
+            "Failed to read DcsrSpec json from {}",
+            spec.as_ref().display()
+        )
+    })?;
+    let dcsr_spec: DcsrSpec = serde_json::from_str(&json)
+        .context("Failed to deserialize DcsrSpec from json")?;
+    let ca_name = dcsr_spec.label.to_string();
+    let signer = cas
+        .get(&ca_name)
+        .ok_or(anyhow!("no Ca \"{}\" for DcsrSpec", ca_name))?;
+
+    info!("Signing DCSR from DcsrSpec: {}", spec.as_ref().display());
+    let dc = signer.sign_dcsrspec(dcsr_spec, cas, &hsm.client)?;
+    hsm.client.close_session()?;
+
+    Ok(dc)
+}
+
+// Process all relevant spec files (CsrSpec & DcsrSpec) from the provided
+// path. From these spec files we determine which Ca should sign them. The
+// resulting certs / credentials are written to `out`.
+pub fn sign_all<P: AsRef<Path>>(
+    cas: &HashMap<String, Ca>,
+    spec: P,
+    state: P,
+    out: P,
+    transport: Transport,
+) -> Result<()> {
+    let spec = fs::canonicalize(spec)?;
+    debug!("canonical spec path: {}", &spec.display());
+
+    let paths = if spec.is_file() {
+        vec![spec.clone()]
+    } else {
+        config::files_with_ext(&spec, CSRSPEC_EXT)?
+            .into_iter()
+            .chain(config::files_with_ext(&spec, DCSRSPEC_EXT)?)
+            .collect::<Vec<PathBuf>>()
+    };
+
+    if paths.is_empty() {
+        return Err(anyhow!(
+            "no files with extensions \"{}\" or \"{}\" found in dir: {}",
+            CSRSPEC_EXT,
+            DCSRSPEC_EXT,
+            &spec.display()
+        ));
+    }
+
+    for path in paths {
+        let filename = path.file_name().unwrap().to_string_lossy();
+
+        let prefix = {
+            // Write the cert to the output directory. We give this output
+            // file the same prefix as the spec file.
+            let filename = match path
+                .file_name()
+                .ok_or(anyhow!("Invalid path to DcsrSpec file"))?
+                .to_os_string()
+                .into_string()
+            {
+                Ok(s) => s,
+                Err(s) => {
+                    return Err(anyhow!(
+                        "Invalid path to CsrSpec file: \"{:?}\"",
+                        s
+                    ))
+                }
+            };
+            match filename.find('.') {
+                Some(i) => filename[..i].to_string(),
+                None => filename,
+            }
+        };
+
+        let (suffix, data) = if filename.ends_with(CSRSPEC_EXT) {
+            (CERT_SUFFIX, sign_csrspec(path, cas)?)
+        } else if filename.ends_with(DCSRSPEC_EXT) {
+            let mut hsm = Hsm::new(
+                0x0002,
+                // TODO: this will probably not work
+                // This assumes that the OKM_HSM_PKCS11_AUTH env var has
+                // already been set up. When this code was in the ca module
+                // that was true but it may not be here.
+                &passwd_from_env("OKM_HSM_PKCS11_AUTH")?,
+                out.as_ref(),
+                state.as_ref(),
+                false,
+                transport,
+            )?;
+            (DCSR_SUFFIX, sign_dcsrspec(path, cas, &mut hsm)?)
+        } else {
+            return Err(anyhow!("Unknown input spec: {}", path.display()));
+        };
+
+        let path =
+            PathBuf::from(out.as_ref()).join(format!("{}.{}", prefix, suffix));
+        debug!("writing credential to: {}", path.display());
+        std::fs::write(path, &data)?;
+    }
+
+    Ok(())
+}
+
+// TODO: this is sketchy ... likely an artifact of bad / no design
+fn passwd_from_env(env_str: &str) -> Result<String> {
+    Ok(env::var(env_str)?
+            .strip_prefix("0002")
+            .ok_or_else(|| anyhow!("Missing key identifier prefix in environment variable \"{env_str}\" that is expected to contain an HSM password"))?
+            .to_string()
+        )
 }
 
 fn main() -> Result<()> {
@@ -336,19 +592,25 @@ fn main() -> Result<()> {
             CaCommand::Initialize {
                 key_spec,
                 pkcs11_path,
-            } => oks::ca::initialize(
-                &key_spec,
-                &pkcs11_path,
-                &args.state,
-                &args.output,
-                args.transport,
-            ),
-            CaCommand::Sign { csr_spec } => oks::ca::sign(
-                &csr_spec,
-                &args.state,
-                &args.output,
-                args.transport,
-            ),
+            } => {
+                let _ = initialize_all_ca(
+                    &key_spec,
+                    &pkcs11_path,
+                    &args.state,
+                    &args.output,
+                )?;
+                Ok(())
+            }
+            CaCommand::Sign { csr_spec } => {
+                let cas = load_all_ca(&args.state)?;
+                sign_all(
+                    &cas,
+                    &csr_spec,
+                    &args.state,
+                    &args.output,
+                    args.transport,
+                )
+            }
         },
         Command::Hsm {
             auth_id,


### PR DESCRIPTION
This commit refactors the functions that previously made up the `ca` module into a type. This is intended to make the code more legible and hopefully more maintainable as well. A significant part of this work was moving the output handling out of the `ca` module and up into `main`. The `ca` module is now limited to processing inputs (key / csr / dscr specs) and generating outputs. This simplifies the `ca` module significantly and moves policy decisions like where to write output files further up the call stack.

The config module was updated to allow serialization of the KeySpec type back to json. We do this so that we can use the type system to ensure that the `Ca` type is only passed valid KeySpecs. Internally this type persists the KeySpec alongside other CA state info which requires serializing it back out to JSON.