### PR TITLE
Implement RngCore and CryptoRng for Hsm.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ dependencies = [
  "p256 0.12.0",
  "pem-rfc7468",
  "rand",
- "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rpassword",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ num-bigint = "0.4.6"
 p256 = "0.12"
 pem-rfc7468 = { version = "0.7.0", features = ["alloc", "std"] }
 rand = "0.8.5"
-rand_chacha = "0.3.1"
+rand_core = { version = "0.6.4", features = ["std"] }
 rpassword = "7.3.1"
 serde = "1.0.210"
 serde_json = "1.0.128"

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,7 +304,7 @@ fn do_ceremony<P: AsRef<Path>>(
     let passwd_new = {
         // assume YubiHSM is in default state: use default auth credentials
         let passwd = "password".to_string();
-        let hsm = Hsm::new(
+        let mut hsm = Hsm::new(
             1,
             &passwd,
             &args.output,
@@ -689,7 +689,7 @@ fn main() -> Result<()> {
         } => {
             let passwd = get_passwd(auth_id, &command)?;
             let auth_id = get_auth_id(auth_id, &command);
-            let hsm = Hsm::new(
+            let mut hsm = Hsm::new(
                 auth_id,
                 &passwd,
                 &args.output,


### PR DESCRIPTION
This allows us to replace use of the ChaCha20 Rng w/ the YubiHSM RNG / Hsm type. The RngCore API fills in a buffer provided by the caller while the YubiHSM `get_pseudo_random` allocates & returns a Vec<u8>. This impedance mismatch between the two APIs makes for unnecessary allocation but saves us some code.