### PR TITLE
Add mechanism to store and retrieve secrets from Iso files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1044,7 @@ dependencies = [
  "clap",
  "env_logger",
  "fs_extra",
+ "glob",
  "hex",
  "log",
  "lpc55_areas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ x509-cert = "0.2.5"
 yubihsm = { git = "https://github.com/oxidecomputer/yubihsm.rs", branch = "session-close", features = ["usb", "untested"] }
 zeroize = "1.8.1"
 zeroize_derive = "1.4.2"
+glob = "0.3.1"

--- a/src/bin/printer-test.rs
+++ b/src/bin/printer-test.rs
@@ -8,7 +8,9 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use hex::ToHex;
 use oks::{
-    alphabet::Alphabet, backup::Share, secret_writer::PrinterSecretWriter,
+    alphabet::Alphabet,
+    backup::Share,
+    secret_writer::{PrinterSecretWriter, SecretWriter},
 };
 use rand::thread_rng;
 use zeroize::Zeroizing;

--- a/src/cdrw.rs
+++ b/src/cdrw.rs
@@ -3,8 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{anyhow, Context, Result};
-use log::warn;
-use std::{fs, path::Path, process::Command};
+use log::{debug, warn};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 use tempfile::{tempdir, TempDir};
 
 pub struct IsoWriter {
@@ -56,5 +60,145 @@ impl IsoWriter {
         }
 
         Ok(())
+    }
+}
+
+pub struct IsoReader {
+    iso_file: PathBuf,
+}
+
+impl IsoReader {
+    pub fn new<P: AsRef<Path>>(iso: P) -> Self {
+        Self {
+            iso_file: PathBuf::from(iso.as_ref()),
+        }
+    }
+
+    pub fn read<P: AsRef<Path>>(&self, path: P) -> Result<Vec<u8>> {
+        let loop_dev = loopback_setup(&self.iso_file)?;
+
+        let tmpdir = tempdir()?;
+        mount(&loop_dev, &tmpdir)?;
+
+        let src = tmpdir.path().join(&path);
+        let data = fs::read(src)?;
+
+        unmount(&tmpdir)?;
+
+        loopback_teardown(&loop_dev)?;
+
+        Ok(data)
+    }
+}
+
+// create loopback device for iso file and get the device path from
+// losetup stdout
+fn loopback_setup<P: AsRef<Path>>(iso_file: P) -> Result<String> {
+    let mut cmd = Command::new("losetup");
+    let output = cmd
+        .arg("-f")
+        .output()
+        .with_context(|| "unable to execute \"losetup\"")?;
+
+    debug!("executing command: \"{:#?}\"", cmd);
+
+    if !output.status.success() {
+        warn!("command failed with status: {}", output.status);
+        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+        return Err(anyhow!("Failed to get next available loopback device"));
+    }
+
+    let loop_dev = String::from(String::from_utf8(output.stdout)?.trim());
+    debug!("got loopback device: {}", loop_dev);
+
+    let mut cmd = Command::new("losetup");
+    let output = cmd
+        .arg(&loop_dev)
+        .arg(iso_file.as_ref())
+        .output()
+        .with_context(|| "failed to execute \"losetup\"")?;
+
+    debug!("executing command: \"{:#?}\"", cmd);
+    if output.status.success() {
+        Ok(loop_dev)
+    } else {
+        warn!("command failed with status: {}", output.status);
+        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+        Err(anyhow!(
+            "Failed to create loopback device {} for ISO file {}",
+            loop_dev,
+            iso_file.as_ref().display()
+        ))
+    }
+}
+
+fn loopback_teardown<P: AsRef<Path>>(loop_dev: P) -> Result<()> {
+    // tear down the loopback device
+    let mut cmd = Command::new("losetup");
+    let output = cmd
+        .arg("-d")
+        .arg(loop_dev.as_ref())
+        .output()
+        .context("failed to execute \"losetup\"")?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        warn!("command failed with status: {}", output.status);
+        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+        Err(anyhow!(
+            "Failed to delete loopback device {}",
+            loop_dev.as_ref().display()
+        ))
+    }
+}
+
+// TODO: sys_mount crate
+fn mount<P: AsRef<Path>, Q: AsRef<Path>>(
+    device: P,
+    mount_point: Q,
+) -> Result<()> {
+    let mut cmd = Command::new("mount");
+    let output = cmd
+        .arg(device.as_ref())
+        .arg(mount_point.as_ref())
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to mount \"{}\" at \"{}\"",
+                device.as_ref().display(),
+                mount_point.as_ref().display()
+            )
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        warn!("command failed with status: {}", output.status);
+        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+        Err(anyhow!(
+            "Failed to mount device {} at {}",
+            device.as_ref().display(),
+            mount_point.as_ref().display()
+        ))
+    }
+}
+
+fn unmount<P: AsRef<Path>>(mount_point: P) -> Result<()> {
+    // unmount now that we've got the data we need
+    let mut cmd = Command::new("umount");
+    let output = cmd.arg(mount_point.as_ref()).output().with_context(|| {
+        format!("failed to unmount \"{}\"", mount_point.as_ref().display())
+    })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        warn!("command failed with status: {}", output.status);
+        warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+        Err(anyhow!(
+            "Failed to unmount at {}",
+            mount_point.as_ref().display()
+        ))
     }
 }

--- a/src/cdrw.rs
+++ b/src/cdrw.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{anyhow, Context, Result};
+use log::warn;
+use std::{fs, path::Path, process::Command};
+use tempfile::{tempdir, TempDir};
+
+pub struct IsoWriter {
+    tmpdir: TempDir,
+}
+
+impl IsoWriter {
+    pub fn new() -> Result<Self> {
+        Ok(Self { tmpdir: tempdir()? })
+    }
+
+    pub fn add(&self, name: &str, data: &[u8]) -> Result<()> {
+        let dst = self.tmpdir.path().join(name);
+
+        fs::write(&dst, data).context(format!(
+            "Failed to write data to: \"{}\"",
+            dst.display()
+        ))?;
+
+        Ok(())
+    }
+
+    pub fn to_iso<P: AsRef<Path>>(self, path: P) -> Result<()> {
+        let mut cmd = Command::new("mkisofs");
+        let output = cmd
+            .arg("-r")
+            .arg("-iso-level")
+            .arg("4")
+            .arg("-o")
+            .arg(path.as_ref())
+            .arg(self.tmpdir.as_ref())
+            .output()
+            .with_context(|| {
+                format!(
+                    "failed to create ISO \"{}\" from dir \"{}\"",
+                    path.as_ref().display(),
+                    self.tmpdir.as_ref().display()
+                )
+            })?;
+
+        if !output.status.success() {
+            warn!("command failed with status: {}", output.status);
+            warn!("stderr: \"{}\"", String::from_utf8_lossy(&output.stderr));
+            return Err(anyhow!(format!(
+                "Failed to make ISO {} from directory {}",
+                path.as_ref().display(),
+                self.tmpdir.as_ref().display()
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod alphabet;
 pub mod backup;
 pub mod ca;
+pub mod cdrw;
 pub mod config;
 pub mod hsm;
 pub mod secret_reader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ use oks::{
         ENV_NEW_PASSWORD, ENV_PASSWORD, KEYSPEC_EXT,
     },
     hsm::Hsm,
-    secret_reader::{self, PasswordReader, SecretInput, StdioPasswordReader},
+    secret_reader::{
+        self, PasswordReader, SecretInputArg, StdioPasswordReader,
+    },
     secret_writer::{self, SecretOutputArg},
     util,
 };
@@ -72,8 +74,8 @@ struct Args {
 #[derive(Subcommand, Debug, PartialEq)]
 enum Command {
     Ca {
-        #[clap(long, env)]
-        auth_method: SecretInput,
+        #[clap(flatten)]
+        auth_method: SecretInputArg,
 
         #[command(subcommand)]
         command: CaCommand,
@@ -156,8 +158,8 @@ enum CaCommand {
 enum HsmCommand {
     /// Generate keys in YubiHSM from specification.
     Generate {
-        #[clap(long, env)]
-        auth_method: SecretInput,
+        #[clap(flatten)]
+        auth_method: SecretInputArg,
 
         #[clap(long, env, default_value = "input")]
         key_spec: PathBuf,
@@ -182,8 +184,8 @@ enum HsmCommand {
         #[clap(long, env, default_value = "input")]
         backups: PathBuf,
 
-        #[clap(long, env)]
-        share_method: SecretInput,
+        #[clap(flatten)]
+        share_method: SecretInputArg,
 
         #[clap(long, env, default_value = "input/verifier.json")]
         verifier: PathBuf,
@@ -191,8 +193,8 @@ enum HsmCommand {
 
     /// Get serial number from YubiHSM and dump to console.
     SerialNumber {
-        #[clap(long, env)]
-        auth_method: SecretInput,
+        #[clap(flatten)]
+        auth_method: SecretInputArg,
     },
 }
 
@@ -237,13 +239,14 @@ fn get_auth_id(auth_id: Option<Id>, command: &HsmCommand) -> Id {
 /// the user with a password prompt.
 fn get_passwd(
     auth_id: Option<Id>,
-    auth_method: &SecretInput,
+    auth_method: &SecretInputArg,
     command: &HsmCommand,
 ) -> Result<Zeroizing<String>> {
     let passwd = match env::var(ENV_PASSWORD).ok() {
         Some(s) => Zeroizing::new(s),
         None => {
-            let passwd_reader = secret_reader::get_passwd_reader(*auth_method);
+            let mut passwd_reader =
+                secret_reader::get_passwd_reader(auth_method)?;
 
             if auth_id.is_some() {
                 // if auth_id was set by the caller but not the password we
@@ -289,7 +292,7 @@ fn get_new_passwd(hsm: Option<&mut Hsm>) -> Result<Zeroizing<String>> {
             }
             // last option: challenge the caller
             None => {
-                let passwd_reader = StdioPasswordReader::default();
+                let mut passwd_reader = StdioPasswordReader::default();
                 loop {
                     let password = passwd_reader.read(PASSWD_NEW)?;
                     let password2 = passwd_reader.read(PASSWD_NEW_2)?;
@@ -682,7 +685,8 @@ fn main() -> Result<()> {
         } => {
             // The CA modules pulls the password out of the environment. If
             // ENV_PASSWORD isn't set the caller will be challenged.
-            let passwd_reader = secret_reader::get_passwd_reader(auth_method);
+            let mut passwd_reader =
+                secret_reader::get_passwd_reader(&auth_method)?;
             let password = passwd_reader.read(PASSWD_PROMPT)?;
             std::env::set_var(ENV_PASSWORD, password.deref());
 
@@ -826,9 +830,9 @@ fn main() -> Result<()> {
                     let verifier = fs::read_to_string(verifier)?;
                     let verifier: Verifier = serde_json::from_str(&verifier)?;
                     let share_itr = secret_reader::get_share_reader(
-                        *share_method,
+                        share_method,
                         verifier,
-                    );
+                    )?;
 
                     let mut shares: Zeroizing<Vec<Share>> =
                         Zeroizing::new(Vec::new());


### PR DESCRIPTION
The implementation is pretty naive but it works. This can be tested by:
- initialize the OKS instance w/ an auth value stored in an ISO & a backup key, splitting the key into one ISO for each share
   ```shell
   $ cargo run --bin oks -- hsm initialize --secret-method iso
   ```
- generating keys for some collection for keyspec files
   ```shell
   $ sudo ./target/debug/oks --state ./ca-test/ --verbose hsm generate --auth-method iso --key-spec ./ca-test/
   ```
- generate CA metadata & self signed certs for `openssl ca`
   ```shell
   sudo ./target/debug/oks --state ./ca-test/ --verbose ca --auth-method iso initialize --pkcs11-path /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so --key-spec ./ca-test/ 2>&1 | tee ca-initialize.log
   ```
- get passwd so we can reset yubishm
```shell
   $ sudo losetup -f
   /dev/loop5
   $ sudo losetup /dev/loop5 password.iso
   $ mktemp -d
   /tmp/tmp.JYqeT85Kwo
   $ sudo mount /dev/loop5 /tmp/tmp.JYqeT85Kwo
   $ cat /tmp/tmp.JYqeT85Kwo/password
   <PASSWD>
   $ sudo umount /tmp/tmp.JYqeT85Kwo
   $ sudo losetup -d /dev/loop5
   ```
- reset yubishm w/ passwd from previous step
   ```shell
   $ cargo run --bin yhsm -- --auth-id 2 reset
   Enter YubiHSM Password: 
   [2024-12-13T00:51:19Z INFO  oks::hsm] resetting device with SN: XXXXXXXXXX
   Are you sure? (y/n):y
   ```
- restore yubishm from backups created @ `hsm init`
   ```shell
   $ sudo ../target/debug/oks --state ./ca-test/ --verbose hsm restore --auth-method iso --backups ./ca-test/ --verifier output/verifier.json 2>&1 | tee restore.log
   ```
- use restored keys to sign some CSRs
   ```shell
   $ sudo ../target/debug/oks --state ./ca-test/ --verbose ca --auth-method iso sign --csr-spec ./ca-test/ 2>&1 | tee ca-sign.log
   ```

NOTE: `oks` commands run as root / sudo above are required as part of mounting ISO files to do auth & restore from key shares.

You can then use `openssl verify` to verify one of the CSRs signed after the restore against the self signed roots created before we reset the yubihsm.