### PR TITLE
add Cdrw as auth and share reader & writers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use oks::{
     },
     hsm::Hsm,
     secret_reader::{
-        self, PasswordReader, SecretInputArg, StdioPasswordReader,
+        self, AuthInputArg, PasswordReader, ShareInputArg, StdioPasswordReader,
     },
     secret_writer::{self, SecretOutputArg},
     util,
@@ -75,7 +75,7 @@ struct Args {
 enum Command {
     Ca {
         #[clap(flatten)]
-        auth_method: SecretInputArg,
+        auth_method: AuthInputArg,
 
         #[command(subcommand)]
         command: CaCommand,
@@ -159,7 +159,7 @@ enum HsmCommand {
     /// Generate keys in YubiHSM from specification.
     Generate {
         #[clap(flatten)]
-        auth_method: SecretInputArg,
+        auth_method: AuthInputArg,
 
         #[clap(long, env, default_value = "input")]
         key_spec: PathBuf,
@@ -185,7 +185,7 @@ enum HsmCommand {
         backups: PathBuf,
 
         #[clap(flatten)]
-        share_method: SecretInputArg,
+        share_method: ShareInputArg,
 
         #[clap(long, env, default_value = "input/verifier.json")]
         verifier: PathBuf,
@@ -194,7 +194,7 @@ enum HsmCommand {
     /// Get serial number from YubiHSM and dump to console.
     SerialNumber {
         #[clap(flatten)]
-        auth_method: SecretInputArg,
+        auth_method: AuthInputArg,
     },
 }
 
@@ -239,7 +239,7 @@ fn get_auth_id(auth_id: Option<Id>, command: &HsmCommand) -> Id {
 /// the user with a password prompt.
 fn get_passwd(
     auth_id: Option<Id>,
-    auth_method: &SecretInputArg,
+    auth_method: &AuthInputArg,
     command: &HsmCommand,
 ) -> Result<Zeroizing<String>> {
     let passwd = match env::var(ENV_PASSWORD).ok() {


### PR DESCRIPTION
The implementation is pretty naive but it works. This can be tested by:

- initialize the OKS instance w/ an auth value stored in an Cdw & a backup key, splitting the key into one Cdw for each share
  ```shell
  cargo run --bin oks -- --state ./ca-test/ hsm initialize --secret-method cdw 2>&1 | tee hsm-initialize.log
  ```
- generating keys for some collection for keyspec files 
  ```shell
  cargo run --bin oks -- --state ./ca-test/ --verbose hsm generate --auth-method cdr --key-spec ./ca-test/
  ```
- generate CA metadata & self signed certs for openssl ca 
  ```shell
  sudo ../target/debug/oks --state ./ca-test/ --verbose ca --auth-method cdr initialize --pkcs11-path /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so --key-spec ./ca-test/ 2>&1 | tee ca-initialize.log
  ```
- get passwd so we can reset yubishm
  ```shell
  $ sudo losetup -f
  /dev/loop5
  $ sudo losetup /dev/loop5 password.iso
  $ mktemp -d
  /tmp/tmp.JYqeT85Kwo
  $ sudo mount /dev/loop5 /tmp/tmp.JYqeT85Kwo
  $ cat /tmp/tmp.JYqeT85Kwo/password
  <PASSWD>
  ```
- reset yubishm w/ passwd from previous step 
  ```shell  
  $ cargo run --bin yhsm -- --auth-id 2 reset
  Enter YubiHSM Password: 
  [2024-12-13T00:51:19Z INFO  oks::hsm] resetting device with SN: 0020780357
  Are you sure? (y/n):y
  ```
- restore yubishm from backups created @ hsm init 
  ```shell
  $ sudo ../target/debug/oks --state ./ca-test/ --verbose hsm restore --auth-method cdr --backups ./ca-test/ --verifier output/ verifier.json 2>&1 | tee restore.log
  ```
- use restored keys to sign some CSRs 
  ```shell
  $ sudo ../target/debug/oks --state ./ca-test/ --verbose ca --auth-method cdr sign --csr-spec ./ca-test/ 2>&1 | tee ca-sign.log
  ```
- verify the cert generated from the csr
  ```shell
  $ openssl verify --trusted ca-test/gimlet-rot-dev-a/ca.cert.pem output/gimlet-rot-code-signing-dev-a2.cert.pem
  ```