### PR TITLE
ChangeAuth: Initial implementation.

### DIFF
--- a/src/secret_reader.rs
+++ b/src/secret_reader.rs
@@ -49,13 +49,16 @@ impl From<SecretInput> for &str {
     }
 }
 
+// thread 'main' panicked at /home/flihp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.18/src/builder/debug_asserts.rs:86:13:
+// Command change-auth: Argument names must be unique, but 'method' is in use by more than one argument or group
+// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 #[derive(Args, Clone, Debug, Default, PartialEq)]
 pub struct AuthInputArg {
-    #[clap(long = "auth-method", env)]
-    method: SecretInput,
+    #[clap(long, env)]
+    auth_method: SecretInput,
 
-    #[clap(long = "auth-device", env)]
-    device: Option<PathBuf>,
+    #[clap(long, env)]
+    auth_device: Option<PathBuf>,
 }
 
 pub trait PasswordReader {
@@ -65,13 +68,13 @@ pub trait PasswordReader {
 pub fn get_passwd_reader(
     input: &AuthInputArg,
 ) -> Result<Box<dyn PasswordReader>> {
-    Ok(match input.method {
+    Ok(match input.auth_method {
         SecretInput::Cdr => {
-            let cdr = CdReader::new(input.device.as_ref());
+            let cdr = CdReader::new(input.auth_device.as_ref());
             Box::new(CdrPasswordReader::new(cdr))
         }
         SecretInput::Iso => {
-            Box::new(IsoPasswordReader::new(input.device.as_ref())?)
+            Box::new(IsoPasswordReader::new(input.auth_device.as_ref())?)
         }
         SecretInput::Stdio => Box::new(StdioPasswordReader {}),
     })

--- a/src/secret_writer.rs
+++ b/src/secret_writer.rs
@@ -49,11 +49,11 @@ pub enum SecretOutput {
 
 #[derive(Args, Clone, Debug, Default, PartialEq)]
 pub struct SecretOutputArg {
-    #[clap(long = "secret-method", env)]
-    method: SecretOutput,
+    #[clap(long, env)]
+    secret_method: SecretOutput,
 
-    #[clap(long = "secret-device", env)]
-    dev: Option<PathBuf>,
+    #[clap(long, env)]
+    secret_device: Option<PathBuf>,
 }
 
 impl From<SecretOutput> for ArgPredicate {
@@ -78,15 +78,15 @@ impl From<SecretOutput> for &str {
 }
 
 pub fn get_writer(output: &SecretOutputArg) -> Result<Box<dyn SecretWriter>> {
-    Ok(match output.method {
+    Ok(match output.secret_method {
         SecretOutput::Cdw => {
-            Box::new(CdwSecretWriter::new(output.dev.as_ref()))
+            Box::new(CdwSecretWriter::new(output.secret_device.as_ref()))
         }
         SecretOutput::Iso => {
-            Box::new(IsoSecretWriter::new(output.dev.as_ref())?)
+            Box::new(IsoSecretWriter::new(output.secret_device.as_ref())?)
         }
         SecretOutput::Printer => {
-            Box::new(PrinterSecretWriter::new(output.dev.as_ref()))
+            Box::new(PrinterSecretWriter::new(output.secret_device.as_ref()))
         }
     })
 }


### PR DESCRIPTION
Clap won't let us flatten both the `AuthInputArg` and `SecretOutputArg` types in the `HsmCommand::ChangeAuth` variant because their member data has naming conflicts. This is despite our explicit renaming w/ the `long` `clap` derive attribute:

```
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.18/src/builder/debug_asserts.rs:86:13:
Command change-auth: Argument names must be unique, but 'method' is in use by more than one argument or group
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We want our auth value to end up w/ auth id 2. Before we do so we create a well known auth value w/ auth id 1. We then create a new auth value, burn it to CD, delete the old value w/ id 2, and then set the new auth value.