### PR TITLE
Upgrade rust from 1.81 to 1.82

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "1.82"


### PR DESCRIPTION
This is the version shipped w/ NixOS 24.11