### PR TITLE
Fix bug that broke authenticating to HSM through PKCS11.

### DIFF
--- a/src/ca.rs
+++ b/src/ca.rs
@@ -182,7 +182,7 @@ tcg-dice-kp-eca = 2.23.133.5.4.100.12
 fn passwd_to_env(env_str: &str, password: &Zeroizing<String>) -> Result<()> {
     use std::ops::Deref;
 
-    let password = Zeroizing::new(format!("0002:{}", password.deref()));
+    let password = Zeroizing::new(format!("0002{}", password.deref()));
     std::env::set_var(env_str, password);
 
     Ok(())


### PR DESCRIPTION
This was introduced a while back in 793ff4c.