### PR TITLE
script/_ceremony: insert SN for detected printer into `printers.conf`

### DIFF
--- a/script/_ceremony
+++ b/script/_ceremony
@@ -4,6 +4,24 @@ set -eou pipefail
 
 . oks-lib.sh
 
+command_on_path lpinfo
+command_on_path systemctl
+command_on_path sed
+command_on_path oks
+
+# NixOS generates `printers.conf` for us but we can't know the printers SN in
+# advance of the first ceremony where it's used. As a work-around we query cups
+# for the serial number for the attached printer and then swap it in
+# `printers.conf` with the place holder `SN_GOES_HERE`
+PRINTER_SN_REGEX='^direct[[:space:]]\+usb:\/\/Brother\/QL-600?serial=\(.*\)$'
+PRINTER_SN=$(lpinfo -v | sed -n "s/$PRINTER_SN_REGEX/\1/p")
+info "Label printer with SN: $PRINTER_SN found"
+
+systemctl stop cups.service
+sed -i "s/SN_GOES_HERE/$PRINTER_SN/g" /etc/cups/printers.conf
+systemctl start cups.service
+info "Label printer with SN: $PRINTER_SN configured"
+
 while read -rsp "Enter password: " OKS_PASSWORD; do
     export OKS_PASSWORD
 


### PR DESCRIPTION
This works in coordination w/ the placeholder for the SN that's setup by OKOS.