### PR TITLE
Find / replace 'any key' to 'Enter key'

### DIFF
--- a/script/ceremony
+++ b/script/ceremony
@@ -36,7 +36,7 @@ wait_for_cd
 write-output
 
 echo -e "\nOutput written to CDW. The ceremony is now complete."
-echo -n "Press any key to poweroff:"
+echo -n "Press the Enter key to poweroff:"
 wait_for_key_press
 
 poweroff

--- a/script/handoff
+++ b/script/handoff
@@ -9,12 +9,12 @@ wait_for_cd
 hash-cd
 eject
 
-echo -e "\nInsert the next OKOS disk into the CD drive, then press any key to continue ..."
+echo -e "\nInsert the next OKOS disk into the CD drive, then press the Enter key to continue ..."
 wait_for_key_press
 wait_for_cd
 hash-cd
 
-echo -e "\nPress any key to reboot into the next OKOS ..."
+echo -e "\nPress the Enter key to reboot into the next OKOS ..."
 wait_for_key_press
 
 # WARNING

--- a/src/secret_reader.rs
+++ b/src/secret_reader.rs
@@ -219,7 +219,7 @@ impl Iterator for StdioShareReader {
                     _ => {
                         print!(
                             "\nexpected 67 characters, got {}.\n\n\
-                            Press any key to try again ...",
+                            Press the Enter key to try again ...",
                             share.len()
                         );
                         match io::stdout().flush() {
@@ -238,7 +238,7 @@ impl Iterator for StdioShareReader {
                 Err(e) => {
                     print!(
                         "Error from `Stdin::read_line`: {e}\n\n\
-                        Press any key to try again ..."
+                        Press the Enter key to try again ..."
                     );
                     match io::stdout().flush() {
                         Ok(_) => (),
@@ -256,7 +256,7 @@ impl Iterator for StdioShareReader {
                 Err(_) => {
                     println!(
                         "Failed to convert the provided hex string into a \
-                        Share ... Press any key to try again",
+                        Share ... Press the Enter key to try again",
                     );
 
                     // wait for a keypress / 1 byte from stdin
@@ -380,7 +380,7 @@ impl Iterator for CdrShareReader {
 
         print!(
             "Place keyshare CD in the drive, close the drive, then press \n\
-               any key to continue: "
+               the Enter key to continue: "
         );
         match io::stdout().flush() {
             Ok(()) => (),
@@ -433,7 +433,7 @@ fn verify(verifier: &Vec<Verifier>, share: &Zeroizing<Share>) -> Result<bool> {
 
     let res = match verifier.verify_share(share.deref()) {
         Ok(_) => {
-            print!("\nShare verified!\n\nPress any key to continue ...");
+            print!("\nShare verified!\n\nPress the Enter key to continue ...");
             io::stdout().flush()?;
 
             // wait for a keypress / 1 byte from stdin
@@ -443,7 +443,7 @@ fn verify(verifier: &Vec<Verifier>, share: &Zeroizing<Share>) -> Result<bool> {
         }
         Err(_) => {
             print!(
-                "\nFailed to verify share :(\n\nPress any key to \
+                "\nFailed to verify share :(\n\nPress the Enter key to \
                 try again ..."
             );
             io::stdout().flush()?;


### PR DESCRIPTION
Everyone keeps pressing 'Alt' or 'Shift' and pointing out that it's not 'any' key.