### PR TITLE
Cargo.lock: update version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "oks"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
This should have been part of 4f8a9c1f926b9027d1b40483410cccc2f3ea001e