### PR TITLE
Remove debug logging of password values.

### DIFF
--- a/src/cdrw.rs
+++ b/src/cdrw.rs
@@ -198,10 +198,7 @@ impl CdWriter {
     }
 
     pub fn write_password(&self, data: &Zeroizing<String>) -> Result<()> {
-        debug!(
-            "Writing password \"{}\"",
-            <Zeroizing<String> as AsRef<str>>::as_ref(data),
-        );
+        debug!("Writing password to CDW");
         self.iso_writer.add("password", data.deref().as_bytes())
     }
 


### PR DESCRIPTION
To trigger this behavior the tool must be run w/ `--verbose`. Our usage of this tool is heavily constrained and audited so we know this has never happened w/ production data. Still best to remove it since it has no value / purpose outside of testing that was completed long ago.