### PR TITLE
Cargo.toml: Update lpc55_support versions to better reflect reality.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ env_logger = "0.11.10"
 fs_extra = "1.3.0"
 hex = { version = "0.4.3", features = ["serde"] }
 log = "0.4.29"
-lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.3.4" }
-lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2.4" }
+lpc55_sign = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.3.5" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false, version = "0.2.5" }
 num-bigint = "0.4.6"
 p256 = "0.13"
 pem-rfc7468 = { version = "1.0.0", features = ["alloc", "std"] }


### PR DESCRIPTION
These are the versions currently being used by Cargo.lock