### PR TITLE
A better solution has been implemented in OKOS

### DIFF
--- a/script/_ceremony
+++ b/script/_ceremony
@@ -24,19 +24,6 @@ while [ $COUNT -gt 0 ]; do
     fi
 done
 
-# NixOS generates `printers.conf` for us but we can't know the printers SN in
-# advance of the first ceremony where it's used. As a work-around we query cups
-# for the serial number for the attached printer and then swap it in
-# `printers.conf` with the place holder `SN_GOES_HERE`
-PRINTER_SN_REGEX='^direct[[:space:]]\+usb:\/\/Brother\/QL-600?serial=\(.*\)$'
-PRINTER_SN=$(lpinfo -v | sed -n "s/$PRINTER_SN_REGEX/\1/p")
-info "Label printer with SN: $PRINTER_SN found"
-
-systemctl stop cups.service
-sed -i "s/SN_GOES_HERE/$PRINTER_SN/g" /etc/cups/printers.conf
-systemctl start cups.service
-info "Label printer with SN: $PRINTER_SN configured"
-
 info "Storage usage before ceremony: "
 oks hsm storage-info --auth-method cdr
 


### PR DESCRIPTION
OKOS now configures the printer for us on boot. This hack is no longer necessary.